### PR TITLE
Add a 'default_open' boolean option to menu configuration

### DIFF
--- a/baton/static/baton/app/src/core/Menu.js
+++ b/baton/static/baton/app/src/core/Menu.js
@@ -59,7 +59,9 @@ let Menu = {
         let pathRexp = new RegExp(voice.url)
         active = pathRexp.test(location.pathname)
       }
-      let li = $('<li />', { 'class': 'top-level ' + voice.type + (active ? ' active' : '') })
+      let li = $('<li />', {
+        'class': 'top-level ' + voice.type + (voice.default_open ? ' default-open' : '') + (active ? ' active' : '')
+      })
       let a = $('<' + (voice.url ? 'a' : 'span') + ' />', {
         href: voice.url || '#'
       }).text(voice.label).appendTo(li)
@@ -102,8 +104,8 @@ let Menu = {
       let p = $(this).parent()
       let depth0 = $('.depth-0')
       let depth1 = p.children('ul')
-      if (p.hasClass('open')) {
-        p.removeClass('open')
+      if ((p.hasClass('open')) || (p.hasClass('default-open'))) {
+        p.removeClass('open default-open')
         depth1.children('.nav-back').remove()
         depth0.css('overflow', 'auto')
       } else {

--- a/baton/static/baton/app/src/styles/_menu.scss
+++ b/baton/static/baton/app/src/styles/_menu.scss
@@ -150,7 +150,8 @@
   }
 
 
-  .open {
+  .open,
+  .default-open {
     @include media-breakpoint-up(lg) {
       .has-children {
         &::after {

--- a/baton/views.py
+++ b/baton/views.py
@@ -97,6 +97,7 @@ class GetAppListJsonView(View):
                 'label': item.get('label', ''),
                 'icon': item.get('icon', None),
                 'url': item.get('url', None),
+                'default_open': item.get('default_open', False),
                 'children': children,
             }
         return None
@@ -127,6 +128,7 @@ class GetAppListJsonView(View):
                 'type': 'app',
                 'label': item.get('label', ''),
                 'icon': item.get('icon', None),
+                'default_open': item.get('default_open', False),
                 'children': children
             }
         return None


### PR DESCRIPTION
Thanks for baton, it is great (you should add a donate / buy me a coffee button!).

I wanted an option for the sidebar menu such that certain blocks would be expanded by default on page load, for a couple of the common sub-menus.

This PR adds that, but I wasn't sure if it is a bit niche! Currently, the PR doesn't update the docs, but if you are interested in accepting it then I can update them with examples.