### PR TITLE
Fix 'active menu item' regex match on 'free' menu items (URLs).

### DIFF
--- a/baton/static/baton/app/src/core/Menu.js
+++ b/baton/static/baton/app/src/core/Menu.js
@@ -54,7 +54,15 @@ let Menu = {
     let self = this
     let mainUl = $('<ul/>', { 'class': 'depth-0' }).appendTo(self.menu)
     data.forEach((voice, index) => {
-      let active = (location.pathname == voice.url)
+      let active = false
+      if (voice.type === 'free') {
+        active = (location.pathname === voice.url)
+      } else {
+        if (voice.url) {
+          let pathRexp = new RegExp(voice.url)
+          active = pathRexp.test(location.pathname)
+        }
+      }
       let li = $('<li />', { 'class': 'top-level ' + voice.type + (active ? ' active' : '') })
       let a = $('<' + (voice.url ? 'a' : 'span') + ' />', {
         href: voice.url || '#'

--- a/baton/static/baton/app/src/core/Menu.js
+++ b/baton/static/baton/app/src/core/Menu.js
@@ -54,11 +54,7 @@ let Menu = {
     let self = this
     let mainUl = $('<ul/>', { 'class': 'depth-0' }).appendTo(self.menu)
     data.forEach((voice, index) => {
-      let active = false
-      if (voice.url) {
-        let pathRexp = new RegExp(voice.url)
-        active = pathRexp.test(location.pathname)
-      }
+      let active = (location.pathname == voice.url)
       let li = $('<li />', { 'class': 'top-level ' + voice.type + (active ? ' active' : '') })
       let a = $('<' + (voice.url ? 'a' : 'span') + ' />', {
         href: voice.url || '#'


### PR DESCRIPTION
Currently the code to decide whether to highlight a 'free' menu item as active or not uses a regex match which over matches.

This PR corrects that requiring a full match (on the pathname only - so still ignoring URL parameters and hash fragments, which makes sense). I ditched the regex as it is no longer required and is more expensive.

**Example 1**

```
{ 'type': 'free', 'label': 'Website Analytics', 'url': '/admin/' }
```

This menu item is always highlighted as `/admin/` matches against all URLs in the admin section.

**Example 2**

```
{ 'type': 'free', 'label': 'Live Photo', 'url': '/photos/' }
```

This would match when we are viewing the URL `/admin/books/photos/`, and highlight the menu item active even though we are not on that page.