### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add `baton` and `baton.autodiscover` to your `INSTALLED_APPS`:
         # ...
         'baton',
         'django.contrib.admin',
-        # ...
+        # ... (Place baton.autodiscover at the very end)
         'baton.autodiscover',
     )
 


### PR DESCRIPTION
Just to make it ultra clear that the autodiscover should be at the very end, otherwise, not all apps will be detected within the `get_list`