### PR TITLE
Update Tabs.js to work with Django 3.1

### DIFF
--- a/baton/static/baton/app/src/core/Tabs.js
+++ b/baton/static/baton/app/src/core/Tabs.js
@@ -42,7 +42,7 @@ let Tabs = {
       .append($('<a />', {
         'class': 'nav-link' + (this.mainOrder === 0 ? ' active' : ''),
         'data-toggle': 'tab',
-        href: '#main'
+        href: '#main-tab'
       }).text(this.main.children('h2').hide().text()).on('click', function () {
         location.hash = $(this).attr('href')
       }))
@@ -115,7 +115,7 @@ let Tabs = {
     this.tabContent = $('<div />', { 'class': 'tab-content' })
     this.tabMain = $('<div />', {
       'class': 'tab-pane' + (this.mainOrder === 0 ? ' active' : ''),
-      'id': 'main'
+      'id': 'main-tab'
     }).appendTo(this.tabContent)
     this.main.parent().children(':not(.nav-tabs):not(.submit-row):not(.errornote)').each((index, el) => {
       $(el).appendTo(self.tabMain)


### PR DESCRIPTION
As diagnosed by @Flewerty in #89, Django 3.1's admin templates contain an element with `id="main"`, so tab switching is broken.  This commit changes the id of the first tab on a page to `main-tab`, avoiding the collision.

Fixes #89