### PR TITLE
Allow fieldsets outside of tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ As you can see these are the rules:
 - For every fieldset you want to put in a separate tab, add a class `baton-tab-fs-CUSTOMNAME`, and add a class `tab-fs-CUSTOMNAME` on the fieldset
 - For every group you want to put in a separate tab, add a class `baton-tab-group-ITEMS`, where items can be inlines (`inline-RELATEDNAME`) and/or fieldsets (`fs-CUSTOMNAME`) separated by a double hypen `--`. Also add a class `tab-fs-CUSTOMNAME` on the fieldset items.
 - Tabs order respects the defined classes order
+- Fieldsets without a specified tab will be added to the main tab. If you want the fieldset to instead display outside of any tabs, add a class `tab-fs-none` to the fieldset. The fieldset will then always be visible regardless of the current tab.
 
 Other features:
 

--- a/baton/static/baton/app/src/core/Tabs.js
+++ b/baton/static/baton/app/src/core/Tabs.js
@@ -117,9 +117,10 @@ let Tabs = {
       'class': 'tab-pane' + (this.mainOrder === 0 ? ' active' : ''),
       'id': 'main-tab'
     }).appendTo(this.tabContent)
-    this.main.parent().children(':not(.nav-tabs):not(.submit-row):not(.errornote)').each((index, el) => {
-      $(el).appendTo(self.tabMain)
-    })
+    this.main.parent().children(':not(.nav-tabs):not(.submit-row):not(.errornote):not(.tab-fs-none)')
+      .each((index, el) => {
+        $(el).appendTo(self.tabMain)
+      })
     this.nav.after(this.tabContent)
 
     let currentOrder = this.mainOrder ? 0 : this.mainOrder + 1

--- a/docs/form_tabs.rst
+++ b/docs/form_tabs.rst
@@ -51,6 +51,7 @@ Rules
 - For every fieldset you want to put in a separate tab, add a class ``baton-tab-fs-CUSTOMNAME``, and add a class ``tab-fs-CUSTOMNAME`` on the fieldset
 - For every group you want to put in a separate tab, add a class ``baton-tab-group-ITEMS``, where items can be inlines (``inline-RELATEDNAME``) and/or fieldsets (``fs-CUSTOMNAME``) separated by a double hypen ``--``. Also add a class ``tab-fs-CUSTOMNAME`` on the fieldset items.
 - Tabs order respects the defined classes order
+- Fieldsets without a specified tab will be added to the main tab. If you want the fieldset to instead display outside of any tabs, add a class ``tab-fs-none`` to the fieldset. The fieldset will then always be visible regardless of the current tab.
 
 Other features:
 


### PR DESCRIPTION
This change will allow use to have fields that are not tied to a specific tab, and will always be visible regardless of the tab. The user just has to add `tab-fs-none` as a class to the fieldsets that they don't want in tabs.

The screenshots below are what the "news" test app looks like with the following fieldsets for the model admin:
```python3
(None, {
    'fields': ('title', 'link', ),
    'classes': ('tab-fs-none',)
}),
('Dates', {
    'fields': ('date', 'datetime', ),
    'classes': ('order-1', 'baton-tabs-init', 'baton-tab-fs-main', 'baton-tab-fs-flags', 'baton-tab-group-fs-attachments--inline-attachments', 'baton-tab-group-fs-videos--inline-videos'),
    'description': 'This is a description text'

}),
('Main', {
    'fields': ('image', 'content', ),
    'classes': ('tab-fs-main', ),
    'description': 'This is a description text'

}),
('Flags', {
    'fields': ('share', 'published', ),
    'classes': ('tab-fs-flags', ),
    'description': 'Set sharing and publishing options'

}),
('Attachments', {
    'fields': ('attachments_summary', ),
    'classes': ('tab-fs-attachments', ),
    'description': 'Add as many attachments as you want'
}),
('Videos', {
    'fields': ('videos_summary', ),
    'classes': ('tab-fs-videos', ),
    'description': 'Add as many videos as you want'

}),
(None, {
    'fields': ('category', ),
    'classes': ('tab-fs-none', ),
})
```
![Main tab](https://user-images.githubusercontent.com/5581459/94751356-37dc3980-033d-11eb-9e3a-9f8cb2d3a3d6.png)

![Flags tab](https://user-images.githubusercontent.com/5581459/94751383-4b87a000-033d-11eb-89c0-5984c5da2e69.png)

This could certainly use some formatting improvements to make it clear that the outer fields are not part of the tabbed section, but I think it's a good start.


