### PR TITLE
html tags stripped out from title at 'view-site' icon

### DIFF
--- a/baton/static/baton/app/src/core/Menu.js
+++ b/baton/static/baton/app/src/core/Menu.js
@@ -135,11 +135,12 @@ let Menu = {
         cls = 'logout'
       }
       let text = $(el).html()
+      let plain = text.replace(/(<([^>]+)>)/gi, "").trim()
       let clone = $(el)
         .clone()
         .html('')
         .attr('class', cls)
-        .attr('title', text)
+        .attr('title', plain ? plain : text)
       if (cls === 'view-site') {
         clone.attr('target', '_blank')
       }


### PR DESCRIPTION
Hi.

Unfortunately we have some html tags (img: country flags) in html which you use for title="..." at yours view-site icons.

Example: `<img src="/static/flags/en.svg" height="15px" width="24px"> English`

I made attempt to remove the html tags and use such result for title=.. if it is non-empty.

I don't know how to build the resulting .min.js
so please could you build the resulting js and try it and if everything is ok (ie title text is still visible),
could you merge this?

Thank you.