### PR TITLE
Optional Google Analytics dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ You can move between the results using the keyboard up and down arrows, and you 
 
 ### <a name="configuration-analytics"></a>ANALYTICS
 
+> :information_source: In order to use the Google Analytics index install baton along the optional dependencies with `$ pip install django-baton[analytics]`
+
 You can create a cool index page displaying some statistics widgets using the Google Analytics API just by defining the `ANALYTICS` setting.
 
 It requires two keys:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Install the last stable release
 
     $ pip install django-baton
 
+> :information_source: In order to use the Google Analytics index install baton along the optional dependencies with `$ pip install django-baton[analytics]`
+
 or clone the repo inside your project
 
     $ git clone https://github.com/otto-torino/django-baton.git

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Install the last stable release
 
     $ pip install django-baton
 
-> :information_source: In order to use the Google Analytics index install baton along the optional dependencies with `$ pip install django-baton[analytics]`
+> :information_source: In order to use the Google Analytics index, install baton along the optional dependencies with `$ pip install django-baton[analytics]`
 
 or clone the repo inside your project
 
@@ -322,7 +322,7 @@ You can move between the results using the keyboard up and down arrows, and you 
 
 ### <a name="configuration-analytics"></a>ANALYTICS
 
-> :information_source: In order to use the Google Analytics index install baton along the optional dependencies with `$ pip install django-baton[analytics]`
+> :information_source: In order to use the Google Analytics index, install baton along the optional dependencies with `$ pip install django-baton[analytics]`
 
 You can create a cool index page displaying some statistics widgets using the Google Analytics API just by defining the `ANALYTICS` setting.
 

--- a/baton/templatetags/baton_tags.py
+++ b/baton/templatetags/baton_tags.py
@@ -1,10 +1,8 @@
 import json
-from google.auth.transport.requests import Request
 from django.urls import reverse
 from django import template
 from django.utils.html import escapejs
 from django.core.exceptions import ImproperlyConfigured
-from google.oauth2 import service_account
 
 from ..config import get_config
 
@@ -43,6 +41,11 @@ def baton_config_value(key):
 
 @register.inclusion_tag('baton/analytics.html', takes_context=True)
 def analytics(context, next=None):
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2 import service_account
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError('django-baton: missing Google Analytics optional dependencies') from e
 
     analytics_settings = get_config('ANALYTICS')
 

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,14 @@ setup(
     url=REPO_URL,
     author='abidibo',
     author_email='abidibo@gmail.com',
-    install_requires=[
-        'google-auth',
-        'google-auth-httplib2',
-        'google-api-python-client',
-        'requests',
-    ],
+    extras_require={
+        'analytics': [
+            'google-auth',
+            'google-auth-httplib2',
+            'google-api-python-client',
+            'requests',
+        ]
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Makes Google Analytics dependencies optional and installable trough `pip install django-baton[analytics]`. A descriptive exception wraps import errors due to such missing dependencies.