### PR TITLE
Move inline JS to separate files

### DIFF
--- a/baton/static/baton/js_snippets/init_analytics.js
+++ b/baton/static/baton/js_snippets/init_analytics.js
@@ -1,0 +1,7 @@
+// Initialize Google Analytics on load
+(function(w,d,s,g,js,fs){
+    g=w.gapi||(w.gapi={});g.analytics={q:[],ready:function(f){this.q.push(f);}};
+    js=d.createElement(s);fs=d.getElementsByTagName(s)[0];
+    js.src='https://apis.google.com/js/platform.js';
+    fs.parentNode.insertBefore(js,fs);js.onload=function(){g.load('analytics');};
+}(window,document,'script'));

--- a/baton/static/baton/js_snippets/init_baton.js
+++ b/baton/static/baton/js_snippets/init_baton.js
@@ -1,0 +1,6 @@
+// Initialize Baton, after reading baton-config from the template
+(function ($, undefined) {
+    $(document).ready(function () {
+        Baton.init(JSON.parse(document.getElementById('baton-config').textContent));
+    })
+})(jQuery, undefined)

--- a/baton/templates/admin/base_site.html
+++ b/baton/templates/admin/base_site.html
@@ -10,13 +10,7 @@
     <!-- <script src="http://localhost:8080/static/baton/app/dist/baton.min.js"></script> -->
     {% baton_config as conf %}
     {{ conf | json_script:"baton-config" }}
-    <script>
-        (function ($, undefined) {
-            $(document).ready(function () {
-                Baton.init(JSON.parse(document.getElementById('baton-config').textContent));
-            })
-        })(jQuery, undefined)
-    </script>
+    <script src="{% static 'baton/js_snippets/init_baton.js' %}"></script>
 {% endblock %}
 
 {% block branding %}

--- a/baton/templates/baton/analytics.html
+++ b/baton/templates/baton/analytics.html
@@ -1,12 +1,5 @@
 {% load i18n %}
-<script>
-    (function(w,d,s,g,js,fs){
-      g=w.gapi||(w.gapi={});g.analytics={q:[],ready:function(f){this.q.push(f);}};
-      js=d.createElement(s);fs=d.getElementsByTagName(s)[0];
-      js.src='https://apis.google.com/js/platform.js';
-      fs.parentNode.insertBefore(js,fs);js.onload=function(){g.load('analytics');};
-    }(window,document,'script'));
-</script>
+<script src="{% static 'baton/js_snippets/init_analytics.js' %}"></script>
 <!-- Include the ActiveUsers component script. -->
 <script src="https://ga-dev-tools.appspot.com/public/javascript/embed-api/components/active-users.js"></script>
 


### PR DESCRIPTION
As mentioned in #234, inline JS prevents setting a more robust Content Security Policy - you need to allow unsafe-inline which is [not recommended](https://csper.io/blog/no-more-unsafe-inline).

From what I can see it's fairly straightforward to move the current inline JS in django-baton to separate static files.

For greater security you could potentially look at a solution like [django-sri](https://pypi.org/project/django-sri/) so all static files have integrity hashes attached, but I don't want to make unsolicited changes to introduce new dependencies!