### PR TITLE
Expand multi-fieldset inlines on errors

### DIFF
--- a/baton/static/baton/app/src/core/ChangeForm.js
+++ b/baton/static/baton/app/src/core/ChangeForm.js
@@ -142,8 +142,8 @@ let ChangeForm = {
         }
       })
     $('.form-row.errors').each(function (index, el) {
-      if ($(el).parent('fieldset').prev('h3.entry-collapsed')) {
-        $(el).parent('fieldset').prev('h3.entry-collapsed').removeClass('entry-collapsed')
+      if ($(el).parent('fieldset').siblings('h3.entry-collapsed')) {
+        $(el).parent('fieldset').siblings('h3.entry-collapsed').removeClass('entry-collapsed')
       }
     })
   },
@@ -151,7 +151,8 @@ let ChangeForm = {
     $('.expand-first').each(function (index, el) {
       if ($(el).find('.inline-related[id$=0] .form-row.errors').length) {
         // inverse logic
-        $(el).find('.inline-related[id$=0] .form-row.errors').parent('fieldset').prev('h3').addClass('entry-collapsed')
+        $(el).find('.inline-related[id$=0] .form-row.errors').parent('fieldset').siblings('h3')
+          .addClass('entry-collapsed')
       }
     })
   },


### PR DESCRIPTION
Correctly expand collapsed inlines containing multiple fieldsets if their fields have errors, even when those errors are not in the first fieldset. Fixes #240.