### PR TITLE
Hide all fieldsets when inline collapsed

### DIFF
--- a/baton/static/baton/app/src/styles/_changeform.scss
+++ b/baton/static/baton/app/src/styles/_changeform.scss
@@ -64,7 +64,7 @@
       }
 
       &.entry-collapsed {
-        + fieldset {
+        ~ fieldset {
           display: none !important;
         }
 
@@ -86,7 +86,7 @@
         }
       }
 
-      + fieldset {
+      ~ fieldset {
         display: none !important;
       }
 
@@ -97,7 +97,7 @@
           }
         }
 
-        + fieldset {
+        ~ fieldset {
           display: block !important;
         }
       }


### PR DESCRIPTION
If an inline contains multiple fieldsets, only the first one is hidden when the inline is collapsed, leaving the rest of the inline visible. This PR changes the `+` CSS selector to `~` in order to match all the fieldsets in question.